### PR TITLE
fix on CPU load query for multi Socket Server

### DIFF
--- a/Decision Making.ps1
+++ b/Decision Making.ps1
@@ -893,7 +893,7 @@ ForEach ($computer in $machines) {
                 
                 [pscustomobject]@{
                     Computer = $computer
-                    CPU = (Get-CimInstance -CimSession $cimSession -ClassName CIM_Processor | Select-Object LoadPercentage | Select-Object -ExpandProperty LoadPercentage)
+                    CPU = (Get-CimInstance -CimSession $cimSession -ClassName CIM_Processor | Measure-Object -Property LoadPercentage -Average).Average
                     Memory = (Get-CimInstance -ClassName Win32_OperatingSystem | Select-Object @{ Name = 'Memory';  Expression = {[int](($($_.TotalVisibleMemorySize - $_.FreePhysicalMemory) / $_.TotalVisibleMemorySize)  * 100)}} | Select-Object -ExpandProperty Memory)
                     LoadIndex = (Get-BrokerMachine -AdminAddress $controller | Where-Object {$_.DNSName -eq $computer}) | Select-Object -expand LoadIndex
                     Sessions = (Get-BrokerMachine -AdminAddress $controller | Where-Object {$_.DNSName -eq $computer}) | Select-Object -expand SessionCount
@@ -961,7 +961,7 @@ ForEach ($computer in $machines) {
                 
                 [pscustomobject]@{
                     Computer = $computer
-                    CPU = Get-CimInstance -CimSession $cimSession -ClassName CIM_Processor | Select-Object LoadPercentage | Select-Object -ExpandProperty LoadPercentage
+                    CPU = (Get-CimInstance -CimSession $cimSession -ClassName CIM_Processor | Measure-Object -Property LoadPercentage -Average).Average
                     Memory = (Get-CimInstance -ClassName Win32_OperatingSystem | Select-Object @{ Name = 'Memory';  Expression = {[int](($($_.TotalVisibleMemorySize - $_.FreePhysicalMemory) / $_.TotalVisibleMemorySize)  * 100)}} | Select-Object -ExpandProperty Memory)
                     LoadIndex = (Get-BrokerMachine -AdminAddress $controller | Where-Object {$_.DNSName -eq $computer}) | Select-Object -expand LoadIndex
                     Sessions = (Get-BrokerMachine -AdminAddress $controller | Where-Object {$_.DNSName -eq $computer}) | Select-Object -expand SessionCount


### PR DESCRIPTION
On Servers configured with multiple sockets The "`Get-CimInstance -CimSession $cimSession -ClassName CIM_Processor`" returns the metrics for each CPU Socket.
![2019-12-03_12h14_20](https://user-images.githubusercontent.com/20661789/70052155-f969d700-15d2-11ea-8d67-7af1b8ef7f8b.png)

This results on an array for the CPU Property in the $metric variable.
![2019-12-03_10h14_13](https://user-images.githubusercontent.com/20661789/70052162-fe2e8b00-15d2-11ea-9ee3-e9840d45c982.png)

Changed the query the make the average for all sockets.