### PR TITLE
Format inputDate in the expected format

### DIFF
--- a/Decision Making.ps1
+++ b/Decision Making.ps1
@@ -102,7 +102,7 @@ $dateNow = $(Get-Date -Format dd/MM/yy).ToString()
 
 #Setup a time object for comparison taking into account the input time for testing
 if ($inputTime) {
-    $inputDate = $([datetime]::ParseExact("$inputTime", "dd/MM/yyyy HH:mm", $null)).ToShortDateString()
+    $inputDate = get-date ([datetime]::ParseExact($inputTime, "dd/MM/yyyy HH:mm", $null)) -UFormat "%d/%m/%Y"
 
     $timesObj = [PSCustomObject]@{
         startTime = [datetime]::ParseExact($("$($inputDate) $($businessStartTime)"), "dd/MM/yyyy HH:mm", $null)


### PR DESCRIPTION
don't rely on the computers culture, but explicitly format the date to the later expected format. This is fixes the issue on a PC that uses dots as separator in date strings.